### PR TITLE
added a few additional features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ npm install
 gulp
 
 ```
+
+
+To add a new template, paste a containing div into the #snippet-container
+in bootstrap.php and give it a unique data-template value.

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -22,13 +22,35 @@
     <a href="/">
       <h1>Rake</h1>
     </a>
-    <p style="color: rgb(240,55,165); font-weight: bold;">Library of elemements</p>
+    <p style="color: rgb(240,55,165); font-weight: bold;">Library of elements</p>
   </header>
 
   <main class="main">
-    <div class="container" style="margin-left: 0; padding-left: 0;">
+    <div id="snippet-container" class="container" style="margin-left: 0; padding-left: 0;">
+      <!--all html snippets  should be direct children of this div-->
 
-      <nav class="navbar navbar-default">
+      <!--these three templates are treated as nestable containers-->
+
+      <div data-template="four-eight-row" class="grid-row row">
+          <div class="col-sm-4" data-container="true"></div>
+          <div class="col-sm-8" data-container="true"></div>
+      </div>
+
+      <div data-template="six-six-row" class="grid-row row ">
+          <div class="col-sm-6" data-container="true"></div>
+          <div class="col-sm-6" data-container="true"></div>
+      </div>
+
+      <div data-template="four-four-four-row" class="grid-row row ">
+          <div class="col-sm-4" data-container="true"></div>
+          <div class="col-sm-4" data-container="true"></div>
+          <div class="col-sm-4" data-container="true"></div>
+      </div>
+
+      <!--end nestable containers-->
+
+
+      <nav data-template="navbar" class="navbar navbar-default">
         <div class="container-fluid">
           <!-- Brand and toggle get grouped for better mobile display -->
           <div class="navbar-header">
@@ -84,7 +106,7 @@
 
       <hr />
 
-      <div class="jumbotron">
+      <div data-template="jumbotron" class="jumbotron">
         <h1>Hello, world!</h1>
         <p>...</p>
         <p><a class="btn btn-primary btn-lg" href="#" role="button">Learn more</a></p>
@@ -92,7 +114,7 @@
 
       <hr />
 
-      <ol class="breadcrumb">
+      <ol data-template="breadcrumb" class="breadcrumb">
         <li><a href="#">Home</a></li>
         <li><a href="#">Library</a></li>
         <li class="active">Data</li>
@@ -100,7 +122,7 @@
 
       <hr />
 
-      <ul class="pagination">
+      <ul data-template="pagination" class="pagination">
         <li>
           <a href="#" aria-label="Previous">
             <span aria-hidden="true">&laquo;</span>
@@ -120,7 +142,7 @@
 
       <hr />
 
-      <table class="table table-striped table-hover table-bordered">
+      <table data-template="table" class="table table-striped table-hover table-bordered">
         <caption>Optional table caption.</caption>
         <thead>
           <tr> <th>#</th> <th>First Name</th> <th>Last Name</th> <th>Username</th>
@@ -134,6 +156,132 @@
       </table>
 
       <hr />
+
+      <div data-template="image-text-block" class="row" style="text-align:center;margin-top:30px">
+        <div class="col-lg-12">
+          <img class="img-circle" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Generic placeholder image" width="140" height="140">
+          <h2>Heading</h2>
+          <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
+          <p><a class="btn btn-default" href="#" role="button">View details »</a></p>
+        </div>
+      </div>
+
+      <hr>
+
+      <div data-template="image-grid" style="margin-top:30px">
+          <div class="row placeholders">
+            <div class="col-xs-6 col-sm-3 placeholder">
+              <img src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" width="200" height="200" class="img-responsive" alt="Generic placeholder thumbnail">
+              <h4>Label</h4>
+              <span class="text-muted">Something else</span>
+            </div>
+            <div class="col-xs-6 col-sm-3 placeholder">
+              <img src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" width="200" height="200" class="img-responsive" alt="Generic placeholder thumbnail">
+              <h4>Label</h4>
+              <span class="text-muted">Something else</span>
+            </div>
+            <div class="col-xs-6 col-sm-3 placeholder">
+              <img src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" width="200" height="200" class="img-responsive" alt="Generic placeholder thumbnail">
+              <h4>Label</h4>
+              <span class="text-muted">Something else</span>
+            </div>
+            <div class="col-xs-6 col-sm-3 placeholder">
+              <img src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" width="200" height="200" class="img-responsive" alt="Generic placeholder thumbnail">
+              <h4>Label</h4>
+              <span class="text-muted">Something else</span>
+            </div>
+          </div>
+        </div>
+
+        <hr>
+
+        <div data-template="header">
+          <div class="page-header">
+            <h1>Example page header <small>Subtext for header</small></h1>
+          </div>
+        </div>
+
+        <hr>
+
+        <div data-template="form" style="margin-top: 30px;">
+          <div class="row">
+            <div class="col-sm-8 col-sm-offset-2">
+              <form class="form-horizontal">
+                <div class="form-group">
+                  <label for="inputEmail3" class="col-sm-2 control-label">Email</label>
+                  <div class="col-sm-10">
+                    <input type="email" class="form-control" id="inputEmail3" placeholder="Email">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label for="inputPassword3" class="col-sm-2 control-label">Password</label>
+                  <div class="col-sm-10">
+                    <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <div class="col-sm-offset-2 col-sm-10">
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox"> Remember me
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <div class="col-sm-offset-2 col-sm-10">
+                    <button type="submit" class="btn btn-default">Sign in</button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <hr>
+
+        <div data-template="media-list" style="margin-top:30px">
+          <ul class="media-list">
+            <li class="media">
+              <div class="media-left"> <a href="#"> <img class="media-object" data-src="holder.js/64x64" alt="64x64" style="width: 64px; height: 64px;" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PCEtLQpTb3VyY2UgVVJMOiBob2xkZXIuanMvNjR4NjQKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTYwODIwYzZjOSB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1NjA4MjBjNmM5Ij48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSIxMy40Njg3NSIgeT0iMzYuNSI+NjR4NjQ8L3RleHQ+PC9nPjwvZz48L3N2Zz4=" data-holder-rendered="true"> </a> </div>
+              <div class="media-body">
+                <h4 class="media-heading">Media heading</h4>
+                <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.</p>
+                <div class="media">
+                  <div class="media-left"> <a href="#"> <img class="media-object" data-src="holder.js/64x64" alt="64x64" style="width: 64px; height: 64px;" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PCEtLQpTb3VyY2UgVVJMOiBob2xkZXIuanMvNjR4NjQKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTYwODIwZWE0ZSB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1NjA4MjBlYTRlIj48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSIxMy40Njg3NSIgeT0iMzYuNSI+NjR4NjQ8L3RleHQ+PC9nPjwvZz48L3N2Zz4=" data-holder-rendered="true"> </a> </div>
+                  <div class="media-body">
+                    <h4 class="media-heading">Nested media heading</h4>
+                    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+                    <div class="media">
+                      <div class="media-left"> <a href="#"> <img class="media-object" data-src="holder.js/64x64" alt="64x64" style="width: 64px; height: 64px;" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PCEtLQpTb3VyY2UgVVJMOiBob2xkZXIuanMvNjR4NjQKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTYwODIwOTgzNyB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1NjA4MjA5ODM3Ij48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSIxMy40Njg3NSIgeT0iMzYuNSI+NjR4NjQ8L3RleHQ+PC9nPjwvZz48L3N2Zz4=" data-holder-rendered="true"> </a> </div>
+                      <div class="media-body">
+                        <h4 class="media-heading">Nested media heading</h4>
+                        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="media">
+                  <div class="media-left"> <a href="#"> <img class="media-object" data-src="holder.js/64x64" alt="64x64" style="width: 64px; height: 64px;" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PCEtLQpTb3VyY2UgVVJMOiBob2xkZXIuanMvNjR4NjQKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTYwODIwNzQ1YiB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1NjA4MjA3NDViIj48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSIxMy40Njg3NSIgeT0iMzYuNSI+NjR4NjQ8L3RleHQ+PC9nPjwvZz48L3N2Zz4=" data-holder-rendered="true"> </a> </div>
+                  <div class="media-body">
+                    <h4 class="media-heading">Nested media heading</h4>
+                    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+                  </div>
+                </div>
+              </div>
+            </li>
+            </ul>
+        </div>
+
+        <div data-template="list-panel">
+          <ul class="list-group">
+            <li class="list-group-item">Cras justo odio</li>
+            <li class="list-group-item">Dapibus ac facilisis in</li>
+            <li class="list-group-item">Morbi leo risus</li>
+            <li class="list-group-item">Porta ac consectetur ac</li>
+            <li class="list-group-item">Vestibulum at eros</li>
+          </ul>
+        </div>
 
     </div>
   </main>

--- a/app/index.php
+++ b/app/index.php
@@ -22,12 +22,10 @@
       <a href="/">
         <h1>Rake</h1>
       </a>
-     <p style="color: rgb(240,55,165); font-weight: bold;">Prototype wireframes</p>
-     <p>
-       <a href="bootstrap.php">
-        with bootstrap Elements
-       </a>
-     </p>
+     <p><span style="color: rgb(240,55,165); font-weight: bold;">Prototype wireframes</span> <a href="bootstrap.php">
+         with Bootstrap elements
+        </a>
+      </p>
   </header>
 
   <main class="main">
@@ -40,36 +38,16 @@
     </div>
 
     <aside id="right" class="components">
-
+        <p><b>Hint:</b> You can edit any text. Use escape key to accept changes.</p>
         <div class="components__controls">
+          <button id="img-download" class="btn btn-default">Snapshot Prototype</button>
           <button type="button" class="btn-reset">Destroy Prototype</button>
         </div>
 
-        <div class="item" data-elem="jumbotron">
-          <div class="item__description" >
-            Jumbo Tron
-          </div>
-        </div>
-        <div class="item" data-elem="navbar">
-          <div class="item__description" >
-            Navbar
-          </div>
-        </div>
-        <div class="item" data-elem="breadcrumb">
-          <div class="item__description" >
-            Breadcrumb
-          </div>
-        </div>
-        <div class="item" data-elem="pagination">
-          <div class="item__description" >
-            Pagination
-          </div>
-        </div>
-        <div class="item" data-elem="table">
-          <div class="item__description" >
-            Table
-          </div>
-        </div>
+        <!--
+            drag and drop buttons will be programmatically added here based
+            on the templates in bootstrap.php
+          -->
 
     </aside>
     </div>
@@ -77,5 +55,10 @@
 
 </div>
 <script async src="javascripts/dist/app.js"></script>
+
+<!-- for downloading an image-->
+<div class="holder-div container" style="overflow:visible;">
+
+</div>
 </body>
 </html>

--- a/app/javascripts/app.js
+++ b/app/javascripts/app.js
@@ -1,26 +1,45 @@
 import $ from 'jquery';
 import dragula from 'dragula';
+import html2canvas from 'html2canvas';
 
 
 function makeElement( data ) {
   var newNode = document.createElement('div');
+  var $newNode = $(newNode);
 
-  var url = "bootstrap.php ." + data;
+  var url = 'bootstrap.php [data-template=' + data + ']';
 
-  $(newNode).load(url, function() {
+  $newNode.load(url, function() {
+
+    //add contenteditable attribute to elements with direct text descendents
+    $newNode.find('*').each(function(index, element){
+
+      var $el = $(element);
+      //get direct text children
+      var text = $el.clone().children().remove().end().text();
+      if (text.trim()) element.contentEditable = true;
+      //allow escape key to remove focus from element that is being edited
+      $el.on('keydown', function(e){ if (e.which === 27) $(this).blur(); });
+
+    });
+
+    //finally, if $newNode is a grid row, add it to the containers list
+    if ($newNode.find(".grid-row")){
+      addDraggableContainers($newNode.find(".grid-row > div").get());
+    }
 
   });
   return newNode;
 }
 
-dragula([document.querySelector('#left'), document.querySelector('#right')], {
+var drake = dragula([document.querySelector('#left'), document.querySelector('#right')], {
   copy: function (el, source) {
     return source === document.querySelector('#right')
   },
   accepts: function (el, target) {
     return target !== document.querySelector('#right')
   },
-  removeOnSpill: true
+  removeOnSpill: true,
 }).on('drop', function ( el ) {
 
     // Check to see if the element has a data attribute
@@ -33,9 +52,73 @@ dragula([document.querySelector('#left'), document.querySelector('#right')], {
       // which will grab the appropriate <div> from bootstrap.php
       el.parentNode.replaceChild(makeElement( data ), el);
 
+
     }
 });
 
+function addDraggableContainers(elementList){
+  [].push.apply(drake.containers, elementList);
+}
+
 $('.btn-reset').on('click', function() {
   alert('Are you sure you want to destroy the prototype? A bit harsh eh.');
+});
+
+/*
+allow user to download a png of the prototype
+ */
+$('#img-download').on('click', function(){
+  var $holderDiv = $('.holder-div');
+  var $prototypeEl = $('.prototype__scroll')
+                      .clone()
+                      .addClass("snapshot")
+                      .css({overflow: 'visible', 'background-color' : 'white', 'padding' : '20px'})
+                      .appendTo($holderDiv);
+
+  html2canvas( $prototypeEl.get()[0], {
+    onrendered: function(canvas) {
+      //remove the clone
+      $holderDiv.empty();
+      // from http://stackoverflow.com/questions/31656689/how-to-save-img-to-users-local-computer-using-html2canvas
+      var a = document.createElement('a');
+       document.body.appendChild(a);
+       a.href = canvas.toDataURL();
+       a.download = 'wireframe.png';
+       a.click();
+       document.body.removeChild(a);
+    }
+  });
 })
+
+/*
+append drag and drop buttons based on the templates in bootstrap.php
+ */
+var $templateContainer = $('<div/>');
+var $itemContainer = $('.components');
+
+$templateContainer.load('bootstrap.php #snippet-container', function(){
+
+
+  $templateContainer.find('#snippet-container > *').each(function(index, element){
+
+      var $el = $(element);
+
+      if (!$el.data('template')) return;
+
+      var $itemParent = $('<div/>')
+      .addClass('item')
+      .attr('data-elem',  $el.data('template'))
+      .appendTo($itemContainer);
+
+      $('<div/>')
+      .addClass('item__description')
+      .text(function(){
+        var text = $el.data('template').replace(/-/g, ' ');
+        text = text[0].toUpperCase() + text.slice(1);
+        return text;
+      })
+      .appendTo($itemParent);
+
+    });
+
+  });

--- a/app/stylesheets/sass/styles.scss
+++ b/app/stylesheets/sass/styles.scss
@@ -19,7 +19,7 @@ h1 {
   width: 100%;
 
   .container {
-    width: 75%;
+    width: 80%;
   }
 }
 
@@ -29,7 +29,7 @@ h1 {
   width: 100%;
   min-height: 100%;
   overflow: hidden;
-  height: calc(100vh - 175px);
+  height: calc(100vh - 125px);
   position: relative;
   padding-top: 80px;
 
@@ -72,7 +72,10 @@ h1 {
   right: 0;
   background: #EEEEEE;
   padding: 1em;
-  width: 25%;
+  width: 20%;
+  height: calc(100vh - 125px);
+  overflow: auto;
+
 
   &__controls {
     margin-bottom: 1em;
@@ -125,6 +128,27 @@ h1 {
 
 }
 
+
+#img-download {
+  width:100%;
+  display:block;
+  margin-bottom: 10px;
+}
+
+.grid-row {
+  border: 4px solid lightGray;
+  padding: 5px;
+  margin-bottom: 10px;
+}
+.grid-row > div {
+  min-height: 50px;
+  border: 1px dashed gray;
+}
+
+// hide the grid row borders when saving to png
+.snapshot .grid-row, .snapshot .grid-row > div {
+  border: none;
+}
 
 
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "dragula": "^3.7.1",
+    "html2canvas": "^0.5.0-beta4",
     "jquery": "^2.2.1"
   }
 }


### PR DESCRIPTION

Hey, I’m going to be at the bootcamp this weekend and as I was looking through the fresh tilled soil repo I saw this project.

I’d be happy to make individual pull requests for any of the changes instead of a single big one, if that would be better.

Here are the changes:

1. Adding a limited ability to use bootstrap's grid rows to make more sophisticated layouts (right now there are 4/8, 6/6, and 4/4/4 rows available)
2. Text elements in the prototype are editable with the contenteditable attribute.
3. Added some more Bootstrap templates.
4. You can download an image of the wireframe to your desktop (this will only work in newer browsers and adds the dependency html2canvas)
5.  A few style tweaks to maximize the prototype container area.
6. Code added in app.js to discover templates from bootstrap.php, so you don’t have to manually add buttons to the html anymore.

Here's a sample wireframe downloaded as a png:
![wireframe-9](https://cloud.githubusercontent.com/assets/3680488/17027387/aaf27264-4f31-11e6-95e8-0879d427bb2f.png)

